### PR TITLE
Fix Scraper Crash

### DIFF
--- a/SteamScraper.TestHarness/FakeGame.cs
+++ b/SteamScraper.TestHarness/FakeGame.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using Unbroken.LaunchBox.Plugins.Data;
+
+namespace SteamScraperTestHarness
+{
+    /// <summary>
+    /// Builds a Moq-backed <see cref="IGame"/> whose additional applications and
+    /// custom fields are stored in real in-memory lists. That way the scraper's
+    /// add/remove calls behave realistically and can be inspected afterwards.
+    /// </summary>
+    internal static class FakeGame
+    {
+        public static Mock<IGame> Create(string platform, string applicationPath)
+        {
+            var additionalApps = new List<IAdditionalApplication>();
+            var customFields = new List<ICustomField>();
+
+            var game = new Mock<IGame>();
+            game.SetupAllProperties();
+
+            // Additional applications ---------------------------------------
+            game.Setup(g => g.GetAllAdditionalApplications())
+                .Returns(() => additionalApps.ToArray());
+
+            game.Setup(g => g.AddNewAdditionalApplication())
+                .Returns(() =>
+                {
+                    var app = new Mock<IAdditionalApplication>();
+                    app.SetupAllProperties();
+                    additionalApps.Add(app.Object);
+                    return app.Object;
+                });
+
+            game.Setup(g => g.TryRemoveAdditionalApplication(It.IsAny<IAdditionalApplication>()))
+                .Returns((IAdditionalApplication a) => additionalApps.Remove(a));
+
+            // Custom fields --------------------------------------------------
+            game.Setup(g => g.GetAllCustomFields())
+                .Returns(() => customFields.ToArray());
+
+            game.Setup(g => g.AddNewCustomField())
+                .Returns(() =>
+                {
+                    var field = new Mock<ICustomField>();
+                    field.SetupAllProperties();
+                    customFields.Add(field.Object);
+                    return field.Object;
+                });
+
+            game.Setup(g => g.TryRemoveCustomField(It.IsAny<ICustomField>()))
+                .Returns((ICustomField f) => customFields.Remove(f));
+
+            // Seed the properties the scraper reads before it writes anything.
+            var obj = game.Object;
+            obj.Platform = platform;
+            obj.ApplicationPath = applicationPath;
+            obj.Title = string.Empty;
+            obj.Notes = string.Empty;
+            obj.Developer = string.Empty;
+            obj.Publisher = string.Empty;
+            obj.GenresString = string.Empty;
+
+            return game;
+        }
+    }
+}

--- a/SteamScraper.TestHarness/Program.cs
+++ b/SteamScraper.TestHarness/Program.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Moq;
+using Unbroken.LaunchBox.Plugins;
+using Unbroken.LaunchBox.Plugins.Data;
+
+namespace SteamScraperTestHarness
+{
+    /// <summary>
+    /// Console harness that drives the SteamScraper plugin's runtime
+    /// (<c>SteamApi.SteamSearchAsync</c>) without needing LaunchBox running.
+    ///
+    /// It injects a Moq-backed <see cref="IGame"/> and <see cref="IDataManager"/>,
+    /// runs the real scraping/download logic against the live Steam API, then
+    /// prints everything the scraper wrote back onto the game.
+    ///
+    /// Usage:
+    ///   SteamScraper.TestHarness [appId] [--tags] [--platform "PC (Windows)"]
+    ///   Defaults: appId = 440 (Team Fortress 2), tags off, platform "PC (Windows)".
+    /// </summary>
+    internal static class Program
+    {
+        private static async Task<int> Main(string[] args)
+        {
+            string appId = "440";
+            string platform = "PC (Windows)";
+            bool enableTags = false;
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string a = args[i];
+                if (a == "--tags")
+                {
+                    enableTags = true;
+                }
+                else if (a == "--platform" && i + 1 < args.Length)
+                {
+                    platform = args[++i];
+                }
+                else if (!a.StartsWith("--"))
+                {
+                    // First positional argument is the Steam appId.
+                    string digits = new string(a.Where(char.IsDigit).ToArray());
+                    if (!string.IsNullOrEmpty(digits))
+                    {
+                        appId = digits;
+                    }
+                }
+            }
+
+            Console.WriteLine("=== SteamScraper Test Harness ===");
+            Console.WriteLine($"appId    : {appId}");
+            Console.WriteLine($"platform : {platform}");
+            Console.WriteLine($"tags     : {enableTags}");
+            Console.WriteLine();
+
+            // The scraper reads properties.json from next to the SteamScraper
+            // assembly. Make sure one exists and reflects the --tags flag.
+            WritePropertiesJson(enableTags);
+
+            // Provide a fake IDataManager so PluginHelper.DataManager.Save() works.
+            var dataManager = new Mock<IDataManager>();
+            dataManager.Setup(d => d.Save(It.IsAny<bool>()))
+                       .Callback(() => Console.WriteLine("[IDataManager.Save called]"));
+            PluginHelper.DataManager = dataManager.Object;
+
+            // Provide a fake IGame and hand it to the plugin's static slot.
+            var game = FakeGame.Create(platform, $"steam://rungameid/{appId}");
+            global::SteamScraper.SteamScraper.game = game.Object;
+
+            try
+            {
+                Console.WriteLine("Running SteamApi.SteamSearchAsync ...\n");
+                await global::SteamScraper.SteamApi.SteamSearchAsync(appId);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("\n!!! Scraper threw an exception:");
+                Console.WriteLine(ex);
+                return 1;
+            }
+
+            PrintResult(game.Object);
+            return 0;
+        }
+
+        private static void WritePropertiesJson(bool enableTags)
+        {
+            string dllDir = Path.GetDirectoryName(
+                typeof(global::SteamScraper.SteamApi).Assembly.Location);
+            string path = Path.Combine(dllDir, "properties.json");
+            string value = enableTags ? "true" : "false";
+            File.WriteAllText(path, "{\r\n  \"customFields\": \"" + value + "\"\r\n}");
+            Console.WriteLine($"Wrote {path} (customFields={value})");
+        }
+
+        private static void PrintResult(IGame game)
+        {
+            Console.WriteLine();
+            Console.WriteLine("=== Metadata written to the game ===");
+            Console.WriteLine($"Title       : {game.Title}");
+            Console.WriteLine($"ReleaseDate : {game.ReleaseDate}");
+            Console.WriteLine($"Developer   : {game.Developer}");
+            Console.WriteLine($"Publisher   : {game.Publisher}");
+            Console.WriteLine($"Genres      : {game.GenresString}");
+            Console.WriteLine($"Notes       : {Truncate(game.Notes, 200)}");
+
+            Console.WriteLine();
+            Console.WriteLine("Additional applications:");
+            foreach (var app in game.GetAllAdditionalApplications())
+            {
+                Console.WriteLine($"  - {app.Name} => {app.ApplicationPath}");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Custom fields:");
+            foreach (var field in game.GetAllCustomFields())
+            {
+                Console.WriteLine($"  - {field.Name} = {Truncate(field.Value, 200)}");
+            }
+
+            string outputDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            Console.WriteLine();
+            Console.WriteLine("Downloaded media (if any) was written under:");
+            Console.WriteLine($"  {Path.Combine(outputDir, "Images")}");
+            Console.WriteLine($"  {Path.Combine(outputDir, "Videos")}");
+        }
+
+        private static string Truncate(string value, int max)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            return value.Length <= max ? value : value.Substring(0, max) + "...";
+        }
+    }
+}

--- a/SteamScraper.TestHarness/README.md
+++ b/SteamScraper.TestHarness/README.md
@@ -1,0 +1,65 @@
+# SteamScraper.TestHarness
+
+A small console app that lets you run the SteamScraper LaunchBox plugin's
+runtime **directly in Visual Studio**, without installing the plugin into
+LaunchBox or launching LaunchBox at all.
+
+## What it does
+
+The plugin's real work happens in `SteamScraper.SteamApi.SteamSearchAsync(appId)`,
+which talks to the live Steam store API, downloads media, and writes metadata
+back onto a LaunchBox `IGame`. This harness:
+
+1. Creates a **fake `IGame`** and **fake `IDataManager`** using [Moq]
+   (LaunchBox's `IGame` has 86 properties + 34 methods, so mocking beats
+   hand-writing a stub).
+2. Injects them into the plugin's static entry points
+   (`PluginHelper.DataManager` and `SteamScraper.game`).
+3. Calls the real `SteamApi.SteamSearchAsync` against the live Steam API.
+4. Prints every field the scraper wrote back (title, release date, developer,
+   publisher, genres, notes, the "Visit Steam Database page" additional
+   application, and the optional `Tags` custom field).
+
+Access to the plugin's `internal` types is granted via
+`<InternalsVisibleTo Include="SteamScraper.TestHarness" />` in
+`SteamScraper/SteamScraper.csproj`.
+
+## Running it
+
+Set **SteamScraper.TestHarness** as the startup project and press F5, or from
+a terminal in the repo root:
+
+```powershell
+dotnet run --project SteamScraper.TestHarness -- 440
+```
+
+### Arguments
+
+| Argument              | Description                                             | Default          |
+| --------------------- | ------------------------------------------------------- | ---------------- |
+| `[appId]`             | Steam appId to scrape (digits are extracted from input) | `440` (Team Fortress 2) |
+| `--tags`              | Enable the SteamSpy "Tags" custom-field code path       | off              |
+| `--platform "<name>"` | Platform name assigned to the fake game                 | `PC (Windows)`   |
+
+Examples:
+
+```powershell
+dotnet run --project SteamScraper.TestHarness -- 620            # Portal 2
+dotnet run --project SteamScraper.TestHarness -- 292030 --tags  # The Witcher 3, with tags
+```
+
+## Where downloaded media goes
+
+Just like inside LaunchBox, the scraper saves images/videos relative to the
+running executable. When run from the harness they land under the harness
+`bin` output directory in `Images/<platform>/...` and `Videos/<platform>/...`.
+The harness prints those paths at the end.
+
+## Notes
+
+- A live internet connection is required (the harness hits the real Steam and
+  SteamSpy APIs).
+- The harness writes a `properties.json` next to the plugin DLL to control the
+  `--tags` behaviour; this mirrors how the plugin reads its config at runtime.
+
+[Moq]: https://github.com/devlooped/moq

--- a/SteamScraper.TestHarness/SteamScraper.TestHarness.csproj
+++ b/SteamScraper.TestHarness/SteamScraper.TestHarness.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <AssemblyName>SteamScraper.TestHarness</AssemblyName>
+    <RootNamespace>SteamScraperTestHarness</RootNamespace>
+    <!-- The referenced plugin is a WinForms library, so match its target. -->
+    <UseWindowsForms>true</UseWindowsForms>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Moq lets us stand in for LaunchBox's IGame / IDataManager without
+         implementing all 86 properties + 34 methods by hand. -->
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SteamScraper\SteamScraper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Unbroken.LaunchBox.Plugins">
+      <HintPath>..\SteamScraper\Launchbox\core\Unbroken.LaunchBox.Plugins.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/SteamScraper.sln
+++ b/SteamScraper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35728.132 d17.12
+VisualStudioVersion = 17.12.35728.132
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SteamScraper", "SteamScraper\SteamScraper.csproj", "{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}"
 EndProject
@@ -10,16 +10,42 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SteamScraper.TestHarness", "SteamScraper.TestHarness\SteamScraper.TestHarness.csproj", "{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Debug|x86.Build.0 = Debug|Any CPU
 		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Release|x64.Build.0 = Release|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F93536B-3600-4F73-9A61-EB2F4F5EFC7C}.Release|x86.Build.0 = Release|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Debug|x86.Build.0 = Debug|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Release|x64.Build.0 = Release|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9B98E97-FD2C-4766-B3D0-16B80D3E6FCC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SteamScraper/AssemblyAttributes.cs
+++ b/SteamScraper/AssemblyAttributes.cs
@@ -1,0 +1,7 @@
+﻿using System.Runtime.CompilerServices;
+
+// GenerateAssemblyInfo is disabled for this project, so the MSBuild
+// <InternalsVisibleTo> item would not emit anything. Declare the attribute in
+// source instead so the test harness can reach the internal SteamApi /
+// SteamScraper types.
+[assembly: InternalsVisibleTo("SteamScraper.TestHarness")]

--- a/SteamScraper/SteamApi.cs
+++ b/SteamScraper/SteamApi.cs
@@ -73,14 +73,13 @@ namespace SteamScraper
                 {
                     developer = null;
                 }
-                if (jsonContent[appId]["data"]["movies"] != null)
-                {
-                    movie = (string)jsonContent[appId]["data"]["movies"][0]["webm"]["480"];
-                }
-                else
-                {
-                    movie = null;
-                }
+                // Steam has changed the "movies" shape over time. Older responses expose downloadable
+                // "webm"/"mp4" objects with "480"/"max" URLs, while newer ones only provide streaming
+                // manifests (dash/hls) which would have to be stitched together.
+                // Probe for a direct file, otherwise fall back to null for now (skip downloading the trailer).
+                var firstMovie = jsonContent[appId]["data"]["movies"]?.FirstOrDefault();
+                movie = (string)(firstMovie?["webm"]?["480"] ?? firstMovie?["webm"]?["max"]
+                                 ?? firstMovie?["mp4"]?["480"] ?? firstMovie?["mp4"]?["max"]);
                 if (jsonContent[appId]["data"]["screenshots"] != null)
                 {
                     screenshots = (JArray)jsonContent[appId]["data"]["screenshots"];
@@ -137,7 +136,8 @@ namespace SteamScraper
             //Download Trailer
             if (movie != null)
             {
-                string moviePath = Path.Combine(destMovies, CleanFileName(gameTitle) + ".webm");
+                string movieExtension = movie.Contains(".mp4") ? ".mp4" : ".webm";
+                string moviePath = Path.Combine(destMovies, CleanFileName(gameTitle) + movieExtension);
                 downloadFile(movie, moviePath);
             }
             
@@ -189,34 +189,44 @@ namespace SteamScraper
 
             var dllPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var dllPathFinal = Path.Combine(dllPath, "properties.json");
-            using (var streamReader = new StreamReader(dllPathFinal))
+            // properties.json is optional. If it's missing or unreadable, fall back to
+            // default settings (custom Tags field disabled) rather than crashing.
+            Properties jsonConfig = new Properties { customFields = "false" };
+            if (File.Exists(dllPathFinal))
             {
-                string jsonFile = streamReader.ReadToEnd();
-                Properties jsonConfig = JsonConvert.DeserializeObject<Properties>(jsonFile);
-                if (jsonConfig.customFields == "true")
+                try
                 {
-                    JToken steamSpyTags = await SteamTags.SteamTag(appId);
-
-                    var oldfields = SteamScraper.game.GetAllCustomFields();
-                    foreach (var field in oldfields)
-                    {
-                        if (field.Name == "Tags")
-                        {
-                            SteamScraper.game.TryRemoveCustomField(field);
-                        }
-                    }
-                    List<string> tagList = new List<string>();
-                    foreach (var Tag in steamSpyTags)
-                    {
-                        JProperty jProperty = Tag.ToObject<JProperty>();
-                        string propertyName = jProperty.Name;
-                        tagList.Add(propertyName);
-                    }
-                    string tagsValue = string.Join(";", tagList);
-                    var tagsField = SteamScraper.game.AddNewCustomField();
-                    tagsField.Name = "Tags";
-                    tagsField.Value = tagsValue;
+                    string jsonFile = File.ReadAllText(dllPathFinal);
+                    jsonConfig = JsonConvert.DeserializeObject<Properties>(jsonFile) ?? jsonConfig;
                 }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Could not read properties.json, using defaults: {ex.Message}");
+                }
+            }
+            if (jsonConfig.customFields == "true")
+            {
+                JToken steamSpyTags = await SteamTags.SteamTag(appId);
+
+                var oldfields = SteamScraper.game.GetAllCustomFields();
+                foreach (var field in oldfields)
+                {
+                    if (field.Name == "Tags")
+                    {
+                        SteamScraper.game.TryRemoveCustomField(field);
+                    }
+                }
+                List<string> tagList = new List<string>();
+                foreach (var Tag in steamSpyTags)
+                {
+                    JProperty jProperty = Tag.ToObject<JProperty>();
+                    string propertyName = jProperty.Name;
+                    tagList.Add(propertyName);
+                }
+                string tagsValue = string.Join(";", tagList);
+                var tagsField = SteamScraper.game.AddNewCustomField();
+                tagsField.Name = "Tags";
+                tagsField.Value = tagsValue;
             }
             //Saves data
             SteamDBLink(appId);

--- a/SteamScraper/SteamScraper.csproj
+++ b/SteamScraper/SteamScraper.csproj
@@ -18,10 +18,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
+      <Version>13.0.4</Version>
     </PackageReference>
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Steam changed their video pipeline which broke the scraper. The scraper now skips pulling in videos that do not exist in the old, expected format and allows the rest of the plugin to work as expected.

- Added test harness to simplify local troubleshooting.
- Updated libraries and removed those deemed unnecessary.
- Plugin now avoids pulling in videos not in the expected file format.
- Properties.json is no longer required to be in the LaunchBox plugin folder.